### PR TITLE
fixed typo rop -> drop in Enemy Header docs

### DIFF
--- a/docs/Enemy Headers.md
+++ b/docs/Enemy Headers.md
@@ -111,7 +111,7 @@ Rules:
 - If value is even, drop missile
 - If value is >$0A, drop large health
 - Else, drop small health
-- Note: All rops have a 50% chance of happening or being nothing
+- Note: All drops have a 50% chance of happening or being nothing
 
 #### Drop Type
 Values:


### PR DESCRIPTION
i fixed a typo in Enemy Headers.md on line 114, where it said rops instead of drops. Thanks for the cool deconstruction!